### PR TITLE
Fixes PHP 8.1 deprecation

### DIFF
--- a/src/Asserts/Dependencies/Elements/ObjectUses.php
+++ b/src/Asserts/Dependencies/Elements/ObjectUses.php
@@ -24,6 +24,7 @@ final class ObjectUses implements IteratorAggregate
         $this->uses = $uses;
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->uses);

--- a/src/Asserts/Methods/Elements/ObjectMethods.php
+++ b/src/Asserts/Methods/Elements/ObjectMethods.php
@@ -24,6 +24,7 @@ final class ObjectMethods implements IteratorAggregate
         $this->methods = $methods;
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->methods);

--- a/src/Asserts/Properties/Elements/ObjectProperties.php
+++ b/src/Asserts/Properties/Elements/ObjectProperties.php
@@ -24,6 +24,7 @@ final class ObjectProperties implements IteratorAggregate
         $this->properties = $properties;
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->properties);

--- a/src/Elements/Layer/Layer.php
+++ b/src/Elements/Layer/Layer.php
@@ -27,6 +27,7 @@ final class Layer implements IteratorAggregate
         $this->objects = $objects;
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->objects);


### PR DESCRIPTION
This pull request fixes PHP 8.1 deprecation around the `getIterator` method:

```
Fatal error: During inheritance of IteratorAggregate: Uncaught Whoops\Exception\ErrorException: Return type of PHPUnit\Architecture\Elements\Layer\Layer::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/nunomaduro/Work/Code/phpunit-architecture-test/src/Elements/Layer/Layer.php:30
```