### PR TITLE
Fix failure with docblocks parameters without type

### DIFF
--- a/src/Asserts/Methods/Elements/MethodDescription.php
+++ b/src/Asserts/Methods/Elements/MethodDescription.php
@@ -72,7 +72,7 @@ final class MethodDescription
 
             if ($type === null) {
                 foreach ($tags as $tag) {
-                    if ($tag->getVariableName() === $name) {
+                    if ($tag->getVariableName() === $name && $tag->getType() !== null) {
                         $type = $objectMethodsDescription->getDocBlockTypeWithNamespace($tag->getType());
                         break;
                     }

--- a/tests/Architecture/MethodsTest.php
+++ b/tests/Architecture/MethodsTest.php
@@ -37,4 +37,11 @@ final class MethodsTest extends TestCase
 
         $this->assertMethodSizeLessThan($filters, 20);
     }
+
+    /**
+     * @param $parameter
+     */
+    public function fakeDocBlockWithoutType($parameter){
+        //
+    }
 }

--- a/tests/Architecture/MethodsTest.php
+++ b/tests/Architecture/MethodsTest.php
@@ -42,6 +42,6 @@ final class MethodsTest extends TestCase
      * @param $parameter
      */
     public function fakeDocBlockWithoutType($parameter){
-        //
+        //this fake method with a non-typed docblock will trigger an error to reproduce the issue solved by https://github.com/ta-tikoma/phpunit-architecture-test/pull/8
     }
 }


### PR DESCRIPTION
This PR will fix a TypeError triggered when a docblock parameter without a type is inspected

to reproduce it, see commit f41e83e32d3594da5c9cdc76879547f500744d5c where I added this in `MethodTest` class:

```php
/**
 * @param $parameter
 */
public function fakeDocBlockWithoutType($parameter){
    //
}
```

it results in all the tests to fail with this error:

> TypeError: PHPUnit\Architecture\Asserts\Dependencies\ObjectDependenciesDescription::getDocBlockTypeWithNamespace(): Argument #1 ($type) must be of type phpDocumentor\Reflection\Type, null given

