### PR TITLE
feat: add configurable excluded paths

### DIFF
--- a/src/Builders/BuildFromTest.php
+++ b/src/Builders/BuildFromTest.php
@@ -15,11 +15,22 @@ trait BuildFromTest
     public function layer(): Layer
     {
         if (self::$layer === null) {
-            ServiceContainer::init();
+            ServiceContainer::init($this->excludedPaths());
 
             self::$layer = new Layer(ObjectsStorage::getObjectMap());
         }
 
         return self::$layer;
+    }
+
+    private function excludedPaths(): array
+    {
+        $defaultExcludedPaths = [
+            'vendor',
+        ];
+
+        return property_exists($this, 'excludedPaths') && is_array($this->excludedPaths)
+            ? array_merge($defaultExcludedPaths, $this->excludedPaths)
+            : $defaultExcludedPaths;
     }
 }

--- a/src/Services/ServiceContainer.php
+++ b/src/Services/ServiceContainer.php
@@ -33,14 +33,17 @@ final class ServiceContainer
 
     public static bool $showException = false;
 
-    public static function init(): void
+    public static function init(array $excludedPaths = []): void
     {
         self::$finder = Finder::create()
             ->files()
             ->followLinks()
-            ->exclude('vendor')
             ->name('/\.php$/')
             ->in(Filesystem::getBaseDir());
+
+        foreach ($excludedPaths as $path) {
+            self::$finder->exclude($path);
+        }
 
         self::$parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
 


### PR DESCRIPTION
This will allow users to exclude other directories besides `vendor`.

In my case, the `flatted` npm package causes problems, as it contains a PHP file that breaks PSR-4 rules and its classes doesn't get autoloaded.

**Usage:**
```php
abstract class ArchitectureTestCase extends TestCase
{
    use ArchitectureAsserts;

    protected array $excludedPaths = [
        'node_modules',
        'tests',
    ];
}
```