### PR TITLE
Avoid function autoloading

### DIFF
--- a/src/Asserts/Dependencies/ObjectDependenciesDescription.php
+++ b/src/Asserts/Dependencies/ObjectDependenciesDescription.php
@@ -38,10 +38,10 @@ abstract class ObjectDependenciesDescription extends ObjectDescriptionBase
             $nameAsString = $name->toString();
 
             return match (true) {
+                function_exists($nameAsString) => true,
                 enum_exists($nameAsString) => true,
                 class_exists($nameAsString) => true,
                 interface_exists($nameAsString) => true,
-                function_exists($nameAsString) => true,
                 trait_exists($nameAsString) => true,
 
                 default => false,


### PR DESCRIPTION
For more details, see https://github.com/saloonphp/xml-wrangler/pull/9

Phpunit-architecture-test is trying to figure out object-dependencies by name by checking:

```php
            return match (true) {
                enum_exists($nameAsString) => true,
                class_exists($nameAsString) => true,
                interface_exists($nameAsString) => true,
                function_exists($nameAsString) => true,
                trait_exists($nameAsString) => true,

                default => false,
            };
```
However, enum_exists, class_exists, interface_exists and trait_exists have a default `autoload = true` flag, which will trigger autoloading. This can be problematic for functions for which there currently is no autoloading mechanism in PHP.

This PR fixes an issue in which a file with function is being autoloaded by the `enum_exists` class by placing the function_exists check first. Another approach would be to disable autoloading on the other *_exists checks to avoid autoloading issues alltogether. But I'm not sure if that's a feature that this library needs.

