### PR TITLE
Update ObjectDependenciesDescription.php

### DIFF
--- a/src/Asserts/Dependencies/ObjectDependenciesDescription.php
+++ b/src/Asserts/Dependencies/ObjectDependenciesDescription.php
@@ -21,6 +21,11 @@ abstract class ObjectDependenciesDescription extends ObjectDescriptionBase
 {
     public ObjectUses $uses;
 
+    public function __construct()
+    {
+        $this->uses = new ObjectUses([]);
+    }
+
     public static function make(string $path): ?self
     {
         /** @var ObjectDescription|null $description */


### PR DESCRIPTION
Fixing error: Typed property PHPUnit\Architecture\Asserts\Dependencies\ObjectDependenciesDescription::$uses must not be accessed before initialization