### PR TITLE
fix: use case-insensitive comparison for functions names

### DIFF
--- a/src/Asserts/Dependencies/DependenciesAsserts.php
+++ b/src/Asserts/Dependencies/DependenciesAsserts.php
@@ -75,7 +75,7 @@ trait DependenciesAsserts
                         }
 
                         foreach ($layerToSearch as $objectToSearch) {
-                            if ($objectToSearch->name === $use) {
+                            if (strcasecmp($objectToSearch->name, $use) === 0) {
                                 $result[] = "$object->name <- $objectToSearch->name";
                             }
                         }


### PR DESCRIPTION
This PR is an attempt to fix [this issue](https://github.com/pestphp/pest/issues/1379), because I believe it should be fixed here rather than in the Pest repository. What do y'll think about it?