### PR TITLE
feat: allow symfony/finder 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
     ],
     "require": {
         "php": "^8.1.0",
-        "phpunit/phpunit": "^10.5.5  || ^11.0.0 || ^12.0.0",
+        "phpunit/phpunit": "^10.5.5 || ^11.0.0 || ^12.0.0",
         "nikic/php-parser": "^4.18.0 || ^5.0.0",
-        "symfony/finder": "^6.4.0 || ^7.0.0",
+        "symfony/finder": "^6.4.0 || ^7.0.0 || ^8.0.0",
         "phpdocumentor/reflection-docblock": "^5.3.0"
     },
     "require-dev": {


### PR DESCRIPTION
ci needs to be triggered again after Symfony 8 is released to validate